### PR TITLE
Support for BigIntegerField / bigint.

### DIFF
--- a/sql_server/pyodbc/creation.py
+++ b/sql_server/pyodbc/creation.py
@@ -36,6 +36,7 @@ class DatabaseCreation(BaseDatabaseCreation):
         'FilePathField':     'nvarchar(%(max_length)s)',
         'FloatField':        'double precision',
         'IntegerField':      'int',
+        'BigIntegerField':   'bigint',
         'IPAddressField':    'nvarchar(15)',
         'NullBooleanField':  'bit',
         'OneToOneField':     'int',

--- a/sql_server/pyodbc/introspection.py
+++ b/sql_server/pyodbc/introspection.py
@@ -7,7 +7,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     # Map type codes to Django Field types.
     data_types_reverse = {
         SQL_AUTOFIELD:                  'AutoField',
-        Database.SQL_BIGINT:            'IntegerField',
+        Database.SQL_BIGINT:            'BigIntegerField',
         #Database.SQL_BINARY:            ,
         Database.SQL_BIT:               'BooleanField',
         Database.SQL_CHAR:              'CharField',


### PR DESCRIPTION
I had a problem where I was using a BigIntegerField as the 'id' field for certain tables and that column was not being created when doing a syncdb. So I did a tiny patch to fix that. Works now.

Here's a minimal example of how it can break without the patch:

``` python
class ObfuscatedPKModel(models.Model):
    class Meta:
        abstract = True
    id = models.BigIntegerField(primary_key = True, db_index = True)
```
